### PR TITLE
Use postgres 11 instead of 12 to match with available tooling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - "3000:3000"
   db:
-    image: postgres
+    image: postgres:11
     volumes:
       - pgdata:/var/lib/postgresql/data
     #ports:


### PR DESCRIPTION
Biggest problem is that heroku postgres doesn't natively support postgres 11 - [(docs)](https://devcenter.heroku.com/articles/heroku-postgresql#version-support)