### PR TITLE
Add ripeness labels to produce-by-garden

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -55,9 +55,9 @@ class StaticPagesController < ApplicationController
         # Check if today falls in one of the two ranges we have
 
         # below means: is today between start_date and end_date inclusive
-        is_ripe_first_range = today <=> start_date >= 0 && end_date <=> today >= 0
+        is_ripe_first_range = (today <=> start_date) >= 0 && (end_date <=> today) >= 0
         # below means: is today between start_date_prev and end_date_prev inclusive
-        is_ripe_second_range = today <=> start_date_prev >= 0 && end_date_prev <=> today >= 0
+        is_ripe_second_range = (today <=> start_date_prev) >= 0 && (end_date_prev <=> today) >= 0
 
         is_ripe = is_ripe_first_range || is_ripe_second_range
         crop_item[:ripe] = if is_ripe

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -11,10 +11,30 @@ class StaticPagesController < ApplicationController
     Crop.all.each do |crop|
       garden_name = Garden.find(crop.garden_id).name
 
-      crop_produce_name = Produce.find(crop.produce).name
-      crop_item = [crop_produce_name]
-      crop_item << crop.description ? crop.description : '-'
+      crop_produce = Produce.find(crop.produce)
+      crop_item = [crop_produce.name] # Add the name
+      crop_item << if crop.description # Add the description, if there is one
+        crop.description
+      else
+        '-'
+      end
+      
+      # Calculate days to ripeness
+      # WAIT UNTIL DATES CHANGED IN DB
+      # Plan for annual produce:
+      #  Get date planted in date object form
+      #  Add produce.duration (an int) to that date object, yields date when crop will be ripe
+      #  Get current date in date object form
+      #  Determine the difference in days between current date and date when ripe
+      #  If date when ripe is in the past, then the crop is ripe now
+      #  If the crop is not ripe now, list the date when ripe
+      # Plan for perennial produce:
+      #  Get current date in date object form
+      #  If the current date is within the date range given in the produce, then the crop is now ripe
+      #  If the crop is not ripe now, list the ripeness date range
+      crop_item << "[ Ripeness Here ]" # placeholder
 
+      # Assemble the array of all crops
       if @all_crops[garden_name]
         @all_crops[garden_name] << crop_item
       else

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -24,7 +24,7 @@ class StaticPagesController < ApplicationController
       # Determine ripeness
       today = Date.today
       if crop_produce.type == "AnnualProduce"
-        planted_date = crop.planted_at
+        planted_date = Date::strptime(crop.planted_at, '%m/%d/%Y')
         ripe_date = planted_date + crop_produce.duration
         is_ripe = today <=> ripe_date >= 0 # means: is today on or after ripe_date
         crop_item[:ripe] = if is_ripe

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -15,23 +15,21 @@ class StaticPagesController < ApplicationController
       crop_item = {
         :name => crop_produce.name,
         :desc => '-',
-        :ripe => '-'
+        :ripe => '-',
       }
-      if crop.description # Add the description, if there is one
-        crop_item[:desc] = crop.description
-      end
-      
+      crop_item[:desc] = crop.description if crop.description # Add the description, if there is one
+
       # Determine ripeness
       today = Date.today
-      if crop_produce.type == "AnnualProduce"
-        planted_date = Date::strptime(crop.planted_at, '%m/%d/%Y')
+      if crop_produce.type == 'AnnualProduce'
+        planted_date = Date.strptime(crop.planted_at, '%m/%d/%Y')
         ripe_date = planted_date + crop_produce.duration
-        is_ripe = today <=> ripe_date >= 0 # means: is today on or after ripe_date
+        is_ripe = (today <=> ripe_date) >= 0 # means: is today on or after ripe_date
         crop_item[:ripe] = if is_ripe
-          'Ripe now'
-        else
-          ripe_date.strftime('Ripe on %-m/%-d/%Y')
-        end
+                             'Ripe now'
+                           else
+                             ripe_date.strftime('Ripe on %-m/%-d/%Y')
+                           end
       else
         start_date_temp = crop_produce.start_date
         end_date_temp = crop_produce.end_date
@@ -40,7 +38,7 @@ class StaticPagesController < ApplicationController
         # cause the start date to come after the end date
         start_date = Date.new(today.year, start_date_temp.month, start_date_temp.day)
         end_date = Date.new(today.year, end_date_temp.month, end_date_temp.day)
-        if start_date <=> end_date > 0 # means: does start_date come after end_date
+        if (start_date <=> end_date).positive? # means: does start_date come after end_date
           # If the two lines above broke that new year thing, this will fix it
           end_date >> 12 # subtract a year
         end
@@ -63,10 +61,10 @@ class StaticPagesController < ApplicationController
 
         is_ripe = is_ripe_first_range || is_ripe_second_range
         crop_item[:ripe] = if is_ripe
-          'Ripe now'
-        else
-          `Ripe between #{start_date.strftime('%-m/%-d')} and #{end_date.strftime('%-m/%-d')}`
-        end
+                             'Ripe now'
+                           else
+                             `Ripe between #{start_date.strftime('%-m/%-d')} and #{end_date.strftime('%-m/%-d')}`
+                           end
       end
 
       # Assemble the array of all crops

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -12,27 +12,62 @@ class StaticPagesController < ApplicationController
       garden_name = Garden.find(crop.garden_id).name
 
       crop_produce = Produce.find(crop.produce)
-      crop_item = [crop_produce.name] # Add the name
-      crop_item << if crop.description # Add the description, if there is one
-        crop.description
-      else
-        '-'
+      crop_item = {
+        :name => crop_produce.name,
+        :desc => '-',
+        :ripe => '-'
+      }
+      if crop.description # Add the description, if there is one
+        crop_item[:desc] = crop.description
       end
       
-      # Calculate days to ripeness
-      # WAIT UNTIL DATES CHANGED IN DB
-      # Plan for annual produce:
-      #  Get date planted in date object form
-      #  Add produce.duration (an int) to that date object, yields date when crop will be ripe
-      #  Get current date in date object form
-      #  Determine the difference in days between current date and date when ripe
-      #  If date when ripe is in the past, then the crop is ripe now
-      #  If the crop is not ripe now, list the date when ripe
-      # Plan for perennial produce:
-      #  Get current date in date object form
-      #  If the current date is within the date range given in the produce, then the crop is now ripe
-      #  If the crop is not ripe now, list the ripeness date range
-      crop_item << "[ Ripeness Here ]" # placeholder
+      # Determine ripeness
+      today = Date.today
+      if crop_produce.type == "AnnualProduce"
+        planted_date = crop.planted_at
+        ripe_date = planted_date + crop_produce.duration
+        is_ripe = today <=> ripe_date >= 0 # means: is today on or after ripe_date
+        crop_item[:ripe] = if is_ripe
+          'Ripe now'
+        else
+          ripe_date.strftime('Ripe on %-m/%-d/%Y')
+        end
+      else
+        start_date_temp = crop_produce.start_date
+        end_date_temp = crop_produce.end_date
+
+        # If a new year started between the start date and end date, these two lines will
+        # cause the start date to come after the end date
+        start_date = Date.new(today.year, start_date_temp.month, start_date_temp.day)
+        end_date = Date.new(today.year, end_date_temp.month, end_date_temp.day)
+        if start_date <=> end_date > 0 # means: does start_date come after end_date
+          # If the two lines above broke that new year thing, this will fix it
+          end_date >> 12 # subtract a year
+        end
+
+        # Suppose the start date is in November and the end date is in February
+        # We want to make sure that a date in December evaluates to being between those dates
+        # and a date in January will also evaluate to being between those dates
+        # If today is in January 2000, then it won't fall between the start_date (Nov 2000)
+        # and end_date (Feb 2001) that we defined above. Therefore, we also want to check
+        # if the date is between Nov 1999 and Feb 2000 (i.e. subtract a year from the range)
+        start_date_prev = start_date << 12 # subtract a year
+        end_date_prev = end_date << 12 # subtract a year
+
+        # Check if today falls in one of the two ranges we have
+
+        # below means: is today between start_date and end_date inclusive
+        is_ripe_first_range = today <=> start_date >= 0 && end_date <=> today >= 0
+        # below means: is today between start_date_prev and end_date_prev inclusive
+        is_ripe_second_range = today <=> start_date_prev >= 0 && end_date_prev <=> today >= 0
+
+        is_ripe = is_ripe_first_range || is_ripe_second_range
+        crop_item[:ripe] = if is_ripe
+          'Ripe now'
+        else
+          `Ripe between #{start_date.strftime('%-m/%-d')} and #{end_date.strftime('%-m/%-d')}`
+        end
+      end
 
       # Assemble the array of all crops
       if @all_crops[garden_name]

--- a/app/models/annual_produce.rb
+++ b/app/models/annual_produce.rb
@@ -1,5 +1,5 @@
 class AnnualProduce < Produce
-  validates :duration, presence: true
+  validates :duration, presence: true # duration in days
   validates_absence_of :start_date
   validates_absence_of :end_date
 end

--- a/app/views/static_pages/produce_by_garden.html.erb
+++ b/app/views/static_pages/produce_by_garden.html.erb
@@ -12,9 +12,9 @@
       </tr>
       <% @all_crops[garden].each do |crop| %>
         <tr>
-          <td><%= crop[0] %></td>
-          <td><%= crop[1] %></td>
-          <td><%= crop[2] %></td>
+          <td><%= crop[:name] %></td>
+          <td><%= crop[:desc] %></td>
+          <td><%= crop[:ripe] %></td>
         </tr>
       <% end %>
     </table>

--- a/app/views/static_pages/produce_by_garden.html.erb
+++ b/app/views/static_pages/produce_by_garden.html.erb
@@ -8,11 +8,13 @@
       <tr>
         <th>Produce</th>
         <th>Description</th>
+        <th>Ripeness</th>
       </tr>
       <% @all_crops[garden].each do |crop| %>
         <tr>
           <td><%= crop[0] %></td>
           <td><%= crop[1] %></td>
+          <td><%= crop[2] %></td>
         </tr>
       <% end %>
     </table>


### PR DESCRIPTION
Adds a column to each table in the produce-by-garden page that displays "Ripe now" if the crop is ripe, and displays the date the crop will be ripe on if the crop is not ripe