### PR TITLE
Adjust crop seeds

### DIFF
--- a/db/seed_data/crops.json
+++ b/db/seed_data/crops.json
@@ -6,16 +6,16 @@
     "description": "North east corner"
   },
   {
-    "produce": 1,
+    "produce": 4,
     "garden_id": 0,
-    "planted_at": "06/06/2019",
-    "description": "North east corner"
+    "planted_at": "11/30/2019",
+    "description": "South east corner"
   },
   {
-    "produce": 1,
+    "produce": 4,
     "garden_id": 0,
-    "planted_at": "06/07/2019",
-    "description": "North east corner"
+    "planted_at": "11/30/2019",
+    "description": "South east corner"
   },
   {
     "produce": 2,
@@ -30,23 +30,23 @@
   {
     "produce": 3,
     "garden_id": 0,
-    "planted_at": "06/08/2019",
+    "planted_at": "06/08/2020",
     "description": "South west corner"
   },
   {
     "produce": 1,
     "garden_id": 1,
-    "planted_at": "05/15/2019"
+    "planted_at": "05/15/2020"
   },
   {
     "produce": 2,
     "garden_id": 1,
-    "planted_at": "05/15/2019"
+    "planted_at": "05/15/2020"
   },
   {
     "produce": 2,
     "garden_id": 1,
-    "planted_at": "05/15/2019"
+    "planted_at": "05/15/2020"
   },
   {
     "produce": 3,


### PR DESCRIPTION
Adjust crop seeds so that they are not all marked "Ripe now" on the
produce-by-garden page