### PR TITLE
Turn off yarn integrity check

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,4 +41,9 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+
+  # Turn off webpacker yarn integrity check - this is deprecated behavior in yarn:
+  # https://github.com/yarnpkg/rfcs/pull/106
+  config.webpacker.check_yarn_integrity = false
 end


### PR DESCRIPTION
The yarn check command has been deprecated: https://github.com/yarnpkg/rfcs/pull/106, and webpacker has not figured out what to do about this: https://github.com/rails/webpacker/issues/2354

Problems are therefore likely to arise as yarn check gets out of sync with the behaviour of yarn install. I have already run into this as a problem while working on https://github.com/AlexanderOtavka/ride-board